### PR TITLE
Auto claude/001 feat add branch count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,14 @@ coverage/
 
 # Temporary text files
 *.txt
+
+# Auto Claude data directory
+.auto-claude/
+
+# Auto Claude generated files
+.auto-claude-security.json
+.auto-claude-status
+.claude_settings.json
+.worktrees/
+.security-key
+logs/security/


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a lightweight branch counting path that avoids GitHub checks and deletion.
> 
> - New `--count`/`-c` flag with `countOnly` flow: prints total, tracked, and untracked branch counts, then exits
> - Skips GitHub CLI/auth checks when in `--count` or `--untracked-only` modes; updates usage/help and examples in `src/index.js`
> - Extends `.gitignore` with `*.txt` and Auto Claude files/dirs (e.g., `.auto-claude/`, `.claude_settings.json`, `.worktrees/`, `logs/security/`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e137fb65ced432acf495d8d1c98a0c188590855b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->